### PR TITLE
Fix BLE Dependency Missing

### DIFF
--- a/radoneye.yaml
+++ b/radoneye.yaml
@@ -4,6 +4,8 @@ esphome:
   board: nodemcu-32s
   includes:
     - radoneye.h
+  libraries:
+  - esp32_ble_tracker=https://github.com/nkolban/ESP32_BLE_Arduino.git
   
 wifi:
   ssid: !secret wifi_ssid


### PR DESCRIPTION
Simply added a library that is missing on some ESPHome instances. Should make the install process easier.
Also should fix this [issue](https://github.com/BrewNinja/RadonEye-ESP32/issues/2).